### PR TITLE
adds fadeOut using toggleClass()

### DIFF
--- a/subbscribe.js
+++ b/subbscribe.js
@@ -93,7 +93,7 @@
 
         $('#subbscribe .close-x').click(function(){
 
-            $('#subbscribe').addClass('animated fadeOut');
+            $('#subbscribe').toggleClass('slideInRight fadeOut');
             $('#subbscribe').one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function(){
 
                 $('#subbscribe').remove();


### PR DESCRIPTION
The animated class already exists on the #subbscribe element so it doesn't need to be added again.  I was having a problem when the slideInRight was not removed.  This pull request replaces the slideInRight class with the fadeOut class.  I debated doing .removeClass('slideInRight').addClass('fadeOut') but I thought this was a cleaner solution.
